### PR TITLE
Updated deprecated BigDecimal instantiation

### DIFF
--- a/lib/speed_format.rb
+++ b/lib/speed_format.rb
@@ -21,7 +21,7 @@ class SpeedFormat
       if not @@units.include?(unit)
         raise ArgumentError, "Not a valid prefix"
       end
-      bps = BigDecimal.new(bps.to_s).abs
+      bps = BigDecimal(bps.to_s).abs
       if bytes == :bytes
         bps /= 8
       end


### PR DESCRIPTION
BigDecimal.new is deprecated, changing to BigDecimal()